### PR TITLE
sensible pod requests/limits for monitoring-stack-operator-deployment

### DIFF
--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -14,8 +14,6 @@ spec:
     listKind: MonitoringStackList
     plural: monitoringstacks
     singular: monitoringstack
-    shortNames:
-    - ms
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/deploy/olm/kustomization.yaml
+++ b/deploy/olm/kustomization.yaml
@@ -9,5 +9,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: monitoring-stack-operator
-  newName: monitoring-stack-operator
-  newTag: 0.0.5
+  newName: quay.io/tsisodia10/monitoring-stack-operator
+  newTag: 0.0.1

--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -14,5 +14,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: monitoring-stack-operator
-  newTag: 0.0.6
+  newTag: 0.0.1
 namespace: operators

--- a/deploy/operator/monitoring-stack-operator-deployment.yaml
+++ b/deploy/operator/monitoring-stack-operator-deployment.yaml
@@ -37,10 +37,10 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             limits:
-              cpu: 200m
-              memory: 100Mi
+              cpu: 600m
+              memory: 400Mi
             requests:
-              cpu: 100m
-              memory: 20Mi
+              cpu: 300m
+              memory: 100Mi
       serviceAccountName: monitoring-stack-operator-sa
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This PR addresses the need for sane limits on the monitoring-stack-operator-deployment's pod resources and the pod would constantly run `OOM`.

Before the PR the resources were:
```
          resources:
            limits:
              cpu: 200m
              memory: 100Mi
            requests:
              cpu: 100m
              memory: 20Mi
 ```
 
 After this change the pod does not run out of memory and restart. 
